### PR TITLE
Allow IAM access keys to be rotated.

### DIFF
--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -109,6 +109,10 @@ Parameters:
     AllowedValues:
       - 'true'
       - 'false'
+  RotateAccessKey:
+    Description: "Increment this number to rotate the IAM access key used by yas3fs when accessing S3. Do not decrement this value."
+    Type: Number
+    Default: 1
 Mappings:
   EnvironmentMap:
     development:
@@ -338,6 +342,7 @@ Resources:
   StorageUserAccessKey:
     Type: AWS::IAM::AccessKey
     Properties:
+      Serial: !Ref RotateAccessKey
       UserName: !Ref StorageUser
   ##
   # Load Balancer


### PR DESCRIPTION
The `RotateAccessKey` parameter has been added, which will make it possible to rotate the IAM access key used by yas3fs when accessing S3. To rotate the key, increment the numeric value of this parameter.

This is a backwards compatible change. The new parameter is *optional*, so does not require existing stacks to be changed until you're ready to cycle the keys.