### PR TITLE
Add defaults for New Relice env variables

### DIFF
--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -24,9 +24,11 @@ Parameters:
   NewrelicLicense:
     Description: "New Relic API License Key"
     Type: String
+    Default: 'deadbeef'
   NewrelicAppName:
     Description: "Name of the app on New Relic"
     Type: String
+    Default: 'N/A'
   SmtpHost:
     Description: "SMTP server hostname"
     Type: String


### PR DESCRIPTION
This is to keep non-NR enabled deployments from breaking.  The default
values will simply be ignored.