### PR TITLE
Parameterize desired count

### DIFF
--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -5,6 +5,10 @@ Parameters:
     Type: String
     AllowedPattern: "[a-z0-9-]+"
     ConstraintDescription: "must only contain lowercase letters, numbers and hyphens"
+  DesiredCount:
+    Description: "Desired number of running containers"
+    Type: String
+    Default: "2"
   DockerImage:
     Description: "Docker image to use (including tag)"
     Type: String
@@ -267,7 +271,7 @@ Resources:
       - HttpListener
     Properties:
       Cluster: !FindInMap [ EnvironmentMap, !Ref Environment, ECSCluster ]
-      DesiredCount: '2'
+      DesiredCount: !Ref DesiredCount
       LoadBalancers:
         - ContainerName: web
           ContainerPort: '80'

--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -25,6 +25,14 @@ Parameters:
     Description: "Database password"
     Type: String
     NoEcho: 'true'
+  Memory:
+    Description: "Max allocated memory for a container"
+    Type: Number
+    Default: 1000
+  MemoryReservation:
+    Description: "Runtime memory for a container"
+    Type: Number
+    Default: 300
   NewrelicLicense:
     Description: "New Relic API License Key"
     Type: String
@@ -185,8 +193,8 @@ Resources:
         - Name: web
           Essential: 'true'
           Image: !Ref DockerImage
-          Memory: 1000
-          MemoryReservation: 300
+          Memory: !Ref Memory
+          MemoryReservation: !Ref MemoryReservation
           Privileged: 'true'
           PortMappings:
             - ContainerPort: 80


### PR DESCRIPTION
Allow adjustment of basic container parameters and numbers using parameters.

Currently, the production cluster has considerable free overhead:
it is running at about 25% memory utilisation and 10-15% processor
utilisation at peak times. 

I want to be able to leverage more of this for intranet, which struggles during peak loading.  However, manual changes are quickly reverted by the template definitions. 