### PR TITLE
Add stack parameters for maintenance mode

### DIFF
--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -133,6 +133,14 @@ Parameters:
     Description: "Increment this number to rotate the IAM access key used by yas3fs when accessing S3. Do not decrement this value."
     Type: Number
     Default: 1
+  MaintenanceMode:
+    Description: "Sets the MAINTNANCE_MODE environment variable on the container. If implemented by the container, setting to 1 will cause a maintenance page to be displayed."
+    Type: Number
+    Default: 0
+  MaintenanceWhitelistIps:
+    Description: "Use in conjunction with MaintenanceMode parameter to configure a whitelist of IP addresses which can bypass the maintenance page. Sets the MAINTENANCE_WHITELIST_IPS environment variable on the container."
+    Type: String
+    Default: ""
 Mappings:
   EnvironmentMap:
     development:
@@ -269,6 +277,10 @@ Resources:
               Value: !Ref WpLoggedInSalt
             - Name: NONCE_SALT
               Value: !Ref WpNonceSalt
+            - Name: MAINTNANCE_MODE
+              Value: !Ref MaintenanceMode
+            - Name: MAINTENANCE_WHITELIST_IPS
+              Value: !Ref MaintenanceWhitelistIps
       Family: !Ref AWS::StackName
   WebService:
     Condition: IsActive


### PR DESCRIPTION
### Description of Changes

I've introduced two parameters to the hosting template, which are to be passed through as environment variables to the docker container. Parameter `MaintenanceMode` becomes env var `MAINTENANCE_MODE`, and `MaintenanceWhitelistIps` becomes `MAINTENANCE_WHITELIST_IPS`.

These are to be used to enable 'maintenance mode' – which, if implemented, can be used to display a maintenance page to end users, meanwhile allowing access to whitelisted IP addresses. Note that it is the responsibility of the container to consume the environment variables and implement the described functionality – this is beyond the scope of this repository. This change simply makes it possible.

Maintenance page functionality has been implemented in [`ministryofjustice/wp-ppj`](https://github.com/ministryofjustice/wp-ppj), so this may be used as a reference. _(Not yet pushed to a public branch.)_

### Backwards Compatibility

This is a backwards compatible change:

- The `MaintenanceMode` parameter defaults to `0` – i.e. do not enable maintenance mode by default
- The new environment variables will be ignored by existing docker containers, since they'll have no knowledge of them.

### Testing Notes

I've tested this branch on one of the PPJ pipelines and can confirm that it behaves as expected.