### PR TITLE
Automatically inject the `APPNAME` environment variable to CodeBuild

### DIFF
--- a/deployment-pipeline/stack-template.yaml
+++ b/deployment-pipeline/stack-template.yaml
@@ -196,6 +196,8 @@ Resources:
             Value: !Ref ComposerUser
           - Name: COMPOSER_PASS
             Value: !Ref ComposerPassword
+          - Name: APPNAME
+            Value: !Ref AppName
       ServiceRole: !GetAtt CodeBuildIAMRole.Arn
       Source:
         Type: CODEPIPELINE


### PR DESCRIPTION
Previously the `APPNAME` environment variable was injected into the CodeBuild job via the `buildspec.yml` file in each individual WordPress app directory. However this makes it more difficult to run multiple pipelines, since the code needs to specify which pipeline its deploying to.

This change will inject the `APPNAME` variable from within the CloudFormation template, meaning the variable can be removed from the codebase. This will make it much easier to deploy a codebase to multiple pipelines.