### PR TITLE
Pass parameter `SmtpPort` through to container environment

### DIFF
--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -247,6 +247,8 @@ Resources:
               Value: !If [ UseCustomDomain, !Ref CustomDomain, !Join [ '', [ !Ref AppName, '.', !FindInMap [ EnvironmentMap, !Ref Environment, Hostname ] ] ] ]
             - Name: SMTP_HOST
               Value: !Ref SmtpHost
+            - Name: SMTP_PORT
+              Value: !Ref SmtpPort
             - Name: SMTP_USER
               Value: !Ref SmtpUsername
             - Name: SMTP_PASS


### PR DESCRIPTION
The value for CloudFormation template parameter `SmtpPort` was not being passed through to the Task Definition environment variables, thus was having no effect on running containers. This was a bug which I have fixed.