### PR TITLE
Change log groups

### DIFF
--- a/deployment-pipeline/stack-template.yaml
+++ b/deployment-pipeline/stack-template.yaml
@@ -410,3 +410,15 @@ Resources:
                   - "arn:aws:route53:::hostedzone/Z29SSUU541F3GJ"
                   - "arn:aws:route53:::hostedzone/Z1DKKIUXG25KAH"
                   - "arn:aws:route53:::hostedzone/ZDGHGJRBZZRPF"
+              - Action:
+                  - "logs:DescribeLogGroups"
+                Effect: Allow
+                Resource: "*"
+              - Action:
+                  - "logs:CreateLogGroup"
+                  - "logs:PutRetentionPolicy"
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:logs:eu-west-2:${AWS::AccountId}:log-group:${AppName}-dev:*'
+                  - !Sub 'arn:aws:logs:eu-west-2:${AWS::AccountId}:log-group:${AppName}-staging:*'
+                  - !Sub 'arn:aws:logs:eu-west-2:${AWS::AccountId}:log-group:${AppName}-prod:*'

--- a/deployment-pipeline/update-stack-template.sh
+++ b/deployment-pipeline/update-stack-template.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+ME=$(basename "$0")
+
+##
+# Update a deployment pipeline stack template
+# Keeping all parameters and the Lambda deployment function the same
+##
+
+USAGE="Update a deployment pipeline stack template
+
+Usage:
+  $ME <stack_name> [<stack_name> ...]
+
+Parameters:
+  <stack_name>      Name of the deployment stack.
+  Update multiple stacks by supplying multiple space separated stack names.
+
+Example usage:
+  $ME example-deploy anotherapp-deploy
+"
+
+if [ -z $1 ]; then
+	echo "$USAGE"
+	exit 1
+fi
+
+PARAM_KEYS=(AppName RepoName RepoBranch GitHubToken ComposerUser ComposerPassword LambdaS3ObjectKey)
+PARAMS=""
+for KEY in "${PARAM_KEYS[@]}"; do
+	PARAMS="$PARAMS ParameterKey=$KEY,UsePreviousValue=true"
+done
+
+for STACK_NAME in "$@"; do
+    aws cloudformation update-stack --region eu-west-1 --template-body "file://$PWD/stack-template.yaml" --parameters $PARAMS --stack-name "$STACK_NAME" --capabilities CAPABILITY_NAMED_IAM
+done

--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -208,7 +208,7 @@ Resources:
             Options:
               awslogs-group: !Ref LogGroup
               awslogs-region: !Ref AWS::Region
-              awslogs-stream-prefix: !Ref AppName
+              awslogs-stream-prefix: web
           Environment:
             - Name: AWS_ACCESS_KEY_ID
               Value: !Ref StorageUserAccessKey

--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -303,7 +303,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !AWS::StackName
+      LogGroupName: !Ref AWS::StackName
       RetentionInDays: 30
 
   ##

--- a/hosting/stack-template.yaml
+++ b/hosting/stack-template.yaml
@@ -146,7 +146,6 @@ Mappings:
     development:
       HostedZone: dev.wp.dsd.io.
       Hostname: dev.wp.dsd.io
-      AWSLogGroup: wp-dev
       ECSCluster: wp-dev
       SSLCertificateArn:  arn:aws:acm:eu-west-2:613903586696:certificate/006ac123-c8b7-4f47-ac49-2dcbc6c6bd45
       ELBSubnet1: subnet-0378637b
@@ -156,7 +155,6 @@ Mappings:
     staging:
       HostedZone: staging.wp.dsd.io.
       Hostname: staging.wp.dsd.io
-      AWSLogGroup: wp-staging
       ECSCluster: wp-staging
       SSLCertificateArn:  arn:aws:acm:eu-west-2:613903586696:certificate/9b35290e-dd85-4a10-b084-956c187ca6cd
       ELBSubnet1: subnet-5d7f6425
@@ -166,7 +164,6 @@ Mappings:
     production:
       HostedZone: prod.wp.dsd.io.
       Hostname: prod.wp.dsd.io
-      AWSLogGroup: wp-production
       ECSCluster: wp-production
       SSLCertificateArn:  arn:aws:acm:eu-west-2:613903586696:certificate/3a60a3f5-a250-42d3-8af0-ae24bfee13eb
       ELBSubnet1: subnet-297f6451
@@ -209,7 +206,7 @@ Resources:
           LogConfiguration:
             LogDriver: awslogs
             Options:
-              awslogs-group: !FindInMap [ EnvironmentMap, !Ref Environment, AWSLogGroup ]
+              awslogs-group: !Ref LogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: !Ref AppName
           Environment:
@@ -300,6 +297,15 @@ Resources:
           TargetGroupArn: !Ref TargetGroup
       Role: ecsServiceRole
       TaskDefinition: !Ref WebTaskDefinition
+  ##
+  # Log group
+  ##
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !AWS::StackName
+      RetentionInDays: 30
+
   ##
   # Uploads storage
   ##


### PR DESCRIPTION
This PR configures hosting stacks to log to their own log groups. Prior to this, stacks were logging into groups based on their ECS cluster – wp-dev, wp-staging & wp-production. This was less than ideal when attempting to analyse logs for a running application due to noise caused by other apps running in the same cluster.