### PR TITLE
Add SecretsManager role to build & Secret vars

### DIFF
--- a/deployment-pipeline/stack-template.yaml
+++ b/deployment-pipeline/stack-template.yaml
@@ -198,6 +198,12 @@ Resources:
             Value: !Ref ComposerPassword
           - Name: APPNAME
             Value: !Ref AppName
+          - Name: DOCKERUSERNAME
+            Type: SECRETS_MANAGER
+            Value: JOTWOC/DockerHub:USERNAME
+          - Name: DOCKERPASSWORD
+            Type: SECRETS_MANAGER
+            Value: JOTWOC/DockerHub:PASSWORD
       ServiceRole: !GetAtt CodeBuildIAMRole.Arn
       Source:
         Type: CODEPIPELINE
@@ -272,6 +278,19 @@ Resources:
               Service:
                 - "codebuild.amazonaws.com"
       Policies:
+        - PolicyName: SecretsManager
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - secretsmanager:GetResourcePolicy
+              - secretsmanager:GetSecretValue
+              - secretsmanager:DescribeSecret
+              - secretsmanager:ListSecretVersionIds
+              - secretsmanager:ListSecrets
+              Resource:
+              - arn:aws:secretsmanager:eu-west-1:613903586696:secret:JOTWOC/DockerHub-lmzZzj
         - PolicyName: Policy
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
This supports DockerHub authentication so that we don't hit the 100
image pull limit on DockerHub.

Two changes have been made, one provides the access credentials 
to AWS Secret Manager and the second provides a policy using an IAM 
role to provide the build pipeline access to Secrets Manager.

Values have been hard coded in so that in the future if we change 
the secret name in Secret Manager we will have to update this file. This 
was done as a trade off so that we are only specifically providing access
to one particular secret.